### PR TITLE
feat: Update frontend templates

### DIFF
--- a/templates/nextjs/package.json
+++ b/templates/nextjs/package.json
@@ -17,9 +17,6 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@assistant-ui/react": "^0.8.0",
-    "@assistant-ui/react-markdown": "^0.8.0",
-    "@assistant-ui/react-syntax-highlighter": "^0.8.0",
     "@langchain/core": "^0.3.42",
     "@langchain/langgraph": "^0.2.55",
     "@langchain/langgraph-api": "^0.0.16",

--- a/templates/nextjs/package.json
+++ b/templates/nextjs/package.json
@@ -1,8 +1,5 @@
 {
   "name": "web",
-  "readme": "https://github.com/langchain-ai/chat-langgraph/blob/main/README.md",
-  "homepage": "https://chat-langgraph.vercel.app",
-  "repository": "https://github.com/langchain-ai/chat-langgraph",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/templates/nextjs/src/components/thread/agent-inbox/components/thread-actions-view.tsx
+++ b/templates/nextjs/src/components/thread/agent-inbox/components/thread-actions-view.tsx
@@ -100,6 +100,7 @@ export function ThreadActionsView({
 
   const threadTitle = interrupt.action_request.action || "Unknown";
   const actionsDisabled = loading || streaming;
+  const ignoreAllowed = interrupt.config.allow_ignore;
 
   return (
     <div className="flex flex-col min-h-full w-full gap-9">
@@ -138,14 +139,16 @@ export function ThreadActionsView({
         >
           Mark as Resolved
         </Button>
-        <Button
-          variant="outline"
-          className="text-gray-800 border-gray-500 font-normal bg-white"
-          onClick={handleIgnore}
-          disabled={actionsDisabled}
-        >
-          Ignore
-        </Button>
+        {ignoreAllowed && (
+          <Button
+            variant="outline"
+            className="text-gray-800 border-gray-500 font-normal bg-white"
+            onClick={handleIgnore}
+            disabled={actionsDisabled}
+          >
+            Ignore
+          </Button>
+        )}
       </div>
 
       {/* Actions */}

--- a/templates/nextjs/src/components/thread/agent-inbox/hooks/use-interrupted-actions.tsx
+++ b/templates/nextjs/src/components/thread/agent-inbox/hooks/use-interrupted-actions.tsx
@@ -87,14 +87,6 @@ export default function useInterruptedActions({
         {
           command: {
             resume: response,
-            update: {
-              messages: [
-                {
-                  type: "human",
-                  content: `Sending type '${response[0].type}' to interrupt...`,
-                },
-              ],
-            },
           },
         },
       );
@@ -266,14 +258,6 @@ export default function useInterruptedActions({
         {
           command: {
             goto: END,
-            update: {
-              messages: [
-                {
-                  type: "human",
-                  content: "Marking thread as resolved.",
-                },
-              ],
-            },
           },
         },
       );

--- a/templates/nextjs/src/components/thread/agent-inbox/index.tsx
+++ b/templates/nextjs/src/components/thread/agent-inbox/index.tsx
@@ -5,10 +5,11 @@ import { HumanInterrupt } from "@langchain/langgraph/prebuilt";
 import { useStreamContext } from "@/providers/Stream";
 
 interface ThreadViewProps {
-  interrupt: HumanInterrupt;
+  interrupt: HumanInterrupt | HumanInterrupt[];
 }
 
 export function ThreadView({ interrupt }: ThreadViewProps) {
+  const interruptObj = Array.isArray(interrupt) ? interrupt[0] : interrupt;
   const thread = useStreamContext();
   const [showDescription, setShowDescription] = useState(false);
   const [showState, setShowState] = useState(false);
@@ -39,13 +40,13 @@ export function ThreadView({ interrupt }: ThreadViewProps) {
       {showSidePanel ? (
         <StateView
           handleShowSidePanel={handleShowSidePanel}
-          description={interrupt.description}
+          description={interruptObj.description}
           values={thread.values}
           view={showState ? "state" : "description"}
         />
       ) : (
         <ThreadActionsView
-          interrupt={interrupt}
+          interrupt={interruptObj}
           handleShowSidePanel={handleShowSidePanel}
           showState={showState}
           showDescription={showDescription}

--- a/templates/nextjs/src/components/thread/agent-inbox/utils.ts
+++ b/templates/nextjs/src/components/thread/agent-inbox/utils.ts
@@ -1,7 +1,7 @@
 import { BaseMessage, isBaseMessage } from "@langchain/core/messages";
 import { format } from "date-fns";
 import { startCase } from "lodash";
-import { HumanResponseWithEdits, SubmitType } from "./types.js";
+import { HumanResponseWithEdits, SubmitType } from "./types";
 import { HumanInterrupt } from "@langchain/langgraph/prebuilt";
 
 export function prettifyText(action: string) {

--- a/templates/nextjs/src/components/thread/history/index.tsx
+++ b/templates/nextjs/src/components/thread/history/index.tsx
@@ -4,7 +4,7 @@ import { Thread } from "@langchain/langgraph-sdk";
 import { useEffect } from "react";
 
 import { getContentString } from "../utils";
-import { useQueryState } from "nuqs";
+import { useQueryState, parseAsBoolean } from "nuqs";
 import {
   Sheet,
   SheetContent,
@@ -71,8 +71,10 @@ function ThreadHistoryLoading() {
 
 export default function ThreadHistory() {
   const isLargeScreen = useMediaQuery("(min-width: 1024px)");
-  const [chatHistoryOpen, setChatHistoryOpen] =
-    useQueryState("chatHistoryOpen");
+  const [chatHistoryOpen, setChatHistoryOpen] = useQueryState(
+    "chatHistoryOpen",
+    parseAsBoolean.withDefault(false),
+  );
 
   const { getThreads, threads, setThreads, threadsLoading, setThreadsLoading } =
     useThreads();
@@ -93,9 +95,9 @@ export default function ThreadHistory() {
           <Button
             className="hover:bg-gray-100"
             variant="ghost"
-            onClick={() => setChatHistoryOpen((p) => (p === "1" ? "0" : "1"))}
+            onClick={() => setChatHistoryOpen((p) => !p)}
           >
-            {chatHistoryOpen === "1" ? (
+            {chatHistoryOpen ? (
               <PanelRightOpen className="size-5" />
             ) : (
               <PanelRightClose className="size-5" />
@@ -113,10 +115,10 @@ export default function ThreadHistory() {
       </div>
       <div className="lg:hidden">
         <Sheet
-          open={chatHistoryOpen === "1" && !isLargeScreen}
+          open={!!chatHistoryOpen && !isLargeScreen}
           onOpenChange={(open) => {
             if (isLargeScreen) return;
-            setChatHistoryOpen(open ? "1" : "0");
+            setChatHistoryOpen(open);
           }}
         >
           <SheetContent side="left" className="lg:hidden flex">
@@ -125,9 +127,7 @@ export default function ThreadHistory() {
             </SheetHeader>
             <ThreadList
               threads={threads}
-              onThreadClick={() =>
-                setChatHistoryOpen((o) => (o === "1" ? "0" : "1"))
-              }
+              onThreadClick={() => setChatHistoryOpen((o) => !o)}
             />
           </SheetContent>
         </Sheet>

--- a/templates/nextjs/src/components/thread/index.tsx
+++ b/templates/nextjs/src/components/thread/index.tsx
@@ -21,7 +21,7 @@ import {
   PanelRightClose,
   SquarePen,
 } from "lucide-react";
-import { useQueryState } from "nuqs";
+import { useQueryState, parseAsBoolean } from "nuqs";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import ThreadHistory from "./history";
 import { toast } from "sonner";
@@ -69,9 +69,14 @@ function ScrollToBottom(props: { className?: string }) {
 
 export function Thread() {
   const [threadId, setThreadId] = useQueryState("threadId");
-  const [chatHistoryOpen, setChatHistoryOpen] =
-    useQueryState("chatHistoryOpen");
-  const [hideToolCalls, setHideToolCalls] = useQueryState("hideToolCalls");
+  const [chatHistoryOpen, setChatHistoryOpen] = useQueryState(
+    "chatHistoryOpen",
+    parseAsBoolean.withDefault(false),
+  );
+  const [hideToolCalls, setHideToolCalls] = useQueryState(
+    "hideToolCalls",
+    parseAsBoolean.withDefault(false),
+  );
   const [input, setInput] = useState("");
   const [firstTokenReceived, setFirstTokenReceived] = useState(false);
   const isLargeScreen = useMediaQuery("(min-width: 1024px)");
@@ -176,8 +181,8 @@ export function Thread() {
           style={{ width: 300 }}
           animate={
             isLargeScreen
-              ? { x: chatHistoryOpen === "1" ? 0 : -300 }
-              : { x: chatHistoryOpen === "1" ? 0 : -300 }
+              ? { x: chatHistoryOpen ? 0 : -300 }
+              : { x: chatHistoryOpen ? 0 : -300 }
           }
           initial={{ x: -300 }}
           transition={
@@ -198,13 +203,12 @@ export function Thread() {
         )}
         layout={isLargeScreen}
         animate={{
-          marginLeft: chatHistoryOpen === "1" ? (isLargeScreen ? 300 : 0) : 0,
-          width:
-            chatHistoryOpen === "1"
-              ? isLargeScreen
-                ? "calc(100% - 300px)"
-                : "100%"
-              : "100%",
+          marginLeft: chatHistoryOpen ? (isLargeScreen ? 300 : 0) : 0,
+          width: chatHistoryOpen
+            ? isLargeScreen
+              ? "calc(100% - 300px)"
+              : "100%"
+            : "100%",
         }}
         transition={
           isLargeScreen
@@ -214,15 +218,13 @@ export function Thread() {
       >
         {!chatStarted && (
           <div className="absolute top-0 left-0 w-full flex items-center justify-between gap-3 p-2 pl-4 z-10">
-            {(chatHistoryOpen !== "1" || !isLargeScreen) && (
+            {(!chatHistoryOpen || !isLargeScreen) && (
               <Button
                 className="hover:bg-gray-100"
                 variant="ghost"
-                onClick={() =>
-                  setChatHistoryOpen((p) => (p === "1" ? "0" : "1"))
-                }
+                onClick={() => setChatHistoryOpen((p) => !p)}
               >
-                {chatHistoryOpen === "1" ? (
+                {chatHistoryOpen ? (
                   <PanelRightOpen className="size-5" />
                 ) : (
                   <PanelRightClose className="size-5" />
@@ -235,15 +237,13 @@ export function Thread() {
           <div className="flex items-center justify-between gap-3 p-2 pl-4 z-10 relative">
             <div className="flex items-center justify-start gap-2 relative">
               <div className="absolute left-0 z-10">
-                {(chatHistoryOpen !== "1" || !isLargeScreen) && (
+                {(!chatHistoryOpen || !isLargeScreen) && (
                   <Button
                     className="hover:bg-gray-100"
                     variant="ghost"
-                    onClick={() =>
-                      setChatHistoryOpen((p) => (p === "1" ? "0" : "1"))
-                    }
+                    onClick={() => setChatHistoryOpen((p) => !p)}
                   >
-                    {chatHistoryOpen === "1" ? (
+                    {chatHistoryOpen ? (
                       <PanelRightOpen className="size-5" />
                     ) : (
                       <PanelRightClose className="size-5" />
@@ -255,7 +255,7 @@ export function Thread() {
                 className="flex gap-2 items-center cursor-pointer"
                 onClick={() => setThreadId(null)}
                 animate={{
-                  marginLeft: chatHistoryOpen !== "1" ? 48 : 0,
+                  marginLeft: !chatHistoryOpen ? 48 : 0,
                 }}
                 transition={{
                   type: "spring",
@@ -355,14 +355,8 @@ export function Thread() {
                         <div className="flex items-center space-x-2">
                           <Switch
                             id="render-tool-calls"
-                            checked={hideToolCalls !== "1" ? false : true}
-                            onCheckedChange={(c) => {
-                              if (c) {
-                                setHideToolCalls("1");
-                              } else {
-                                setHideToolCalls("0");
-                              }
-                            }}
+                            checked={hideToolCalls ?? false}
+                            onCheckedChange={setHideToolCalls}
                           />
                           <Label
                             htmlFor="render-tool-calls"

--- a/templates/nextjs/src/components/thread/markdown-styles.css
+++ b/templates/nextjs/src/components/thread/markdown-styles.css
@@ -1,0 +1,45 @@
+/* Base markdown styles */
+.markdown-content code:not(pre code) {
+  background-color: rgba(0, 0, 0, 0.05);
+  padding: 0.2em 0.4em;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+.markdown-content a {
+  color: #0070f3;
+  text-decoration: none;
+}
+
+.markdown-content a:hover {
+  text-decoration: underline;
+}
+
+.markdown-content blockquote {
+  border-left: 4px solid #ddd;
+  padding-left: 1rem;
+  color: #666;
+}
+
+.markdown-content pre {
+  overflow-x: auto;
+}
+
+.markdown-content table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.markdown-content th,
+.markdown-content td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+
+.markdown-content th {
+  background-color: #f2f2f2;
+}
+
+.markdown-content tr:nth-child(even) {
+  background-color: #f9f9f9;
+}

--- a/templates/nextjs/src/components/thread/markdown-text.tsx
+++ b/templates/nextjs/src/components/thread/markdown-text.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import "@assistant-ui/react-markdown/styles/dot.css";
+import "./markdown-styles.css";
 
-import {
-  CodeHeaderProps,
-  unstable_memoizeMarkdownComponents as memoizeMarkdownComponents,
-  useIsMarkdownCodeBlock,
-} from "@assistant-ui/react-markdown";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeKatex from "rehype-katex";
@@ -20,37 +15,10 @@ import { cn } from "@/lib/utils";
 
 import "katex/dist/katex.min.css";
 
-const MarkdownTextImpl = ({ children }: { children: string }) => {
-  return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkMath]}
-      rehypePlugins={[rehypeKatex]}
-      components={defaultComponents}
-    >
-      {children}
-    </ReactMarkdown>
-  );
-};
-
-export const MarkdownText = memo(MarkdownTextImpl);
-
-const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
-  const { isCopied, copyToClipboard } = useCopyToClipboard();
-  const onCopy = () => {
-    if (!code || isCopied) return;
-    copyToClipboard(code);
-  };
-
-  return (
-    <div className="flex items-center justify-between gap-4 rounded-t-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white">
-      <span className="lowercase [&>span]:text-xs">{language}</span>
-      <TooltipIconButton tooltip="Copy" onClick={onCopy}>
-        {!isCopied && <CopyIcon />}
-        {isCopied && <CheckIcon />}
-      </TooltipIconButton>
-    </div>
-  );
-};
+interface CodeHeaderProps {
+  language?: string;
+  code: string;
+}
 
 const useCopyToClipboard = ({
   copiedDuration = 3000,
@@ -71,8 +39,26 @@ const useCopyToClipboard = ({
   return { isCopied, copyToClipboard };
 };
 
-const defaultComponents = memoizeMarkdownComponents({
-  h1: ({ className, ...props }) => (
+const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
+  const { isCopied, copyToClipboard } = useCopyToClipboard();
+  const onCopy = () => {
+    if (!code || isCopied) return;
+    copyToClipboard(code);
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-t-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white">
+      <span className="lowercase [&>span]:text-xs">{language}</span>
+      <TooltipIconButton tooltip="Copy" onClick={onCopy}>
+        {!isCopied && <CopyIcon />}
+        {isCopied && <CheckIcon />}
+      </TooltipIconButton>
+    </div>
+  );
+};
+
+const defaultComponents: any = {
+  h1: ({ className, ...props }: { className?: string }) => (
     <h1
       className={cn(
         "mb-8 scroll-m-20 text-4xl font-extrabold tracking-tight last:mb-0",
@@ -81,7 +67,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h2: ({ className, ...props }) => (
+  h2: ({ className, ...props }: { className?: string }) => (
     <h2
       className={cn(
         "mb-4 mt-8 scroll-m-20 text-3xl font-semibold tracking-tight first:mt-0 last:mb-0",
@@ -90,7 +76,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h3: ({ className, ...props }) => (
+  h3: ({ className, ...props }: { className?: string }) => (
     <h3
       className={cn(
         "mb-4 mt-6 scroll-m-20 text-2xl font-semibold tracking-tight first:mt-0 last:mb-0",
@@ -99,7 +85,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h4: ({ className, ...props }) => (
+  h4: ({ className, ...props }: { className?: string }) => (
     <h4
       className={cn(
         "mb-4 mt-6 scroll-m-20 text-xl font-semibold tracking-tight first:mt-0 last:mb-0",
@@ -108,7 +94,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h5: ({ className, ...props }) => (
+  h5: ({ className, ...props }: { className?: string }) => (
     <h5
       className={cn(
         "my-4 text-lg font-semibold first:mt-0 last:mb-0",
@@ -117,19 +103,19 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h6: ({ className, ...props }) => (
+  h6: ({ className, ...props }: { className?: string }) => (
     <h6
       className={cn("my-4 font-semibold first:mt-0 last:mb-0", className)}
       {...props}
     />
   ),
-  p: ({ className, ...props }) => (
+  p: ({ className, ...props }: { className?: string }) => (
     <p
       className={cn("mb-5 mt-5 leading-7 first:mt-0 last:mb-0", className)}
       {...props}
     />
   ),
-  a: ({ className, ...props }) => (
+  a: ({ className, ...props }: { className?: string }) => (
     <a
       className={cn(
         "text-primary font-medium underline underline-offset-4",
@@ -138,28 +124,28 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  blockquote: ({ className, ...props }) => (
+  blockquote: ({ className, ...props }: { className?: string }) => (
     <blockquote
       className={cn("border-l-2 pl-6 italic", className)}
       {...props}
     />
   ),
-  ul: ({ className, ...props }) => (
+  ul: ({ className, ...props }: { className?: string }) => (
     <ul
       className={cn("my-5 ml-6 list-disc [&>li]:mt-2", className)}
       {...props}
     />
   ),
-  ol: ({ className, ...props }) => (
+  ol: ({ className, ...props }: { className?: string }) => (
     <ol
       className={cn("my-5 ml-6 list-decimal [&>li]:mt-2", className)}
       {...props}
     />
   ),
-  hr: ({ className, ...props }) => (
+  hr: ({ className, ...props }: { className?: string }) => (
     <hr className={cn("my-5 border-b", className)} {...props} />
   ),
-  table: ({ className, ...props }) => (
+  table: ({ className, ...props }: { className?: string }) => (
     <table
       className={cn(
         "my-5 w-full border-separate border-spacing-0 overflow-y-auto",
@@ -168,7 +154,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  th: ({ className, ...props }) => (
+  th: ({ className, ...props }: { className?: string }) => (
     <th
       className={cn(
         "bg-muted px-4 py-2 text-left font-bold first:rounded-tl-lg last:rounded-tr-lg [&[align=center]]:text-center [&[align=right]]:text-right",
@@ -177,7 +163,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  td: ({ className, ...props }) => (
+  td: ({ className, ...props }: { className?: string }) => (
     <td
       className={cn(
         "border-b border-l px-4 py-2 text-left last:border-r [&[align=center]]:text-center [&[align=right]]:text-right",
@@ -186,7 +172,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  tr: ({ className, ...props }) => (
+  tr: ({ className, ...props }: { className?: string }) => (
     <tr
       className={cn(
         "m-0 border-b p-0 first:border-t [&:last-child>td:first-child]:rounded-bl-lg [&:last-child>td:last-child]:rounded-br-lg",
@@ -195,30 +181,65 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  sup: ({ className, ...props }) => (
+  sup: ({ className, ...props }: { className?: string }) => (
     <sup
       className={cn("[&>a]:text-xs [&>a]:no-underline", className)}
       {...props}
     />
   ),
-  pre: ({ className, ...props }) => (
+  pre: ({ className, ...props }: { className?: string }) => (
     <pre
       className={cn(
-        "overflow-x-auto rounded-b-lg bg-black p-4 text-white max-w-4xl",
+        "overflow-x-auto rounded-lg bg-black text-white max-w-4xl",
         className,
       )}
       {...props}
     />
   ),
-  code: function Code({ className, ...props }) {
-    const isCodeBlock = useIsMarkdownCodeBlock();
+  code: ({
+    className,
+    children,
+    ...props
+  }: {
+    className?: string;
+    children: React.ReactNode;
+  }) => {
+    const match = /language-(\w+)/.exec(className || "");
+
+    if (match) {
+      const language = match[1];
+      const code = String(children).replace(/\n$/, "");
+
+      return (
+        <>
+          <CodeHeader language={language} code={code} />
+          <SyntaxHighlighter language={language} className={className}>
+            {code}
+          </SyntaxHighlighter>
+        </>
+      );
+    }
+
     return (
-      <code
-        className={cn(!isCodeBlock && "rounded font-semibold", className)}
-        {...props}
-      />
+      <code className={cn("rounded font-semibold", className)} {...props}>
+        {children}
+      </code>
     );
   },
-  CodeHeader,
-  SyntaxHighlighter,
-});
+};
+
+const MarkdownTextImpl: FC<{ children: string }> = ({ children }) => {
+  return (
+    <div className="markdown-content">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+        components={defaultComponents}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+};
+
+export const MarkdownText = memo(MarkdownTextImpl);

--- a/templates/nextjs/src/components/thread/messages/ai.tsx
+++ b/templates/nextjs/src/components/thread/messages/ai.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { parsePartialJson } from "@langchain/core/output_parsers";
 import { useStreamContext } from "@/providers/Stream";
 import { AIMessage, Checkpoint, Message } from "@langchain/langgraph-sdk";
@@ -13,7 +11,7 @@ import { MessageContentComplex } from "@langchain/core/messages";
 import { Fragment } from "react/jsx-runtime";
 import { isAgentInboxInterruptSchema } from "@/lib/agent-inbox-interrupt";
 import { ThreadView } from "../agent-inbox";
-import { useQueryState } from "nuqs";
+import { useQueryState, parseAsBoolean } from "nuqs";
 
 function CustomComponent({
   message,
@@ -76,7 +74,10 @@ export function AssistantMessage({
   handleRegenerate: (parentCheckpoint: Checkpoint | null | undefined) => void;
 }) {
   const contentString = getContentString(message.content);
-  const [hideToolCalls] = useQueryState("hideToolCalls");
+  const [hideToolCalls] = useQueryState(
+    "hideToolCalls",
+    parseAsBoolean.withDefault(false),
+  );
 
   const thread = useStreamContext();
   const isLastMessage =
@@ -100,7 +101,7 @@ export function AssistantMessage({
   const hasAnthropicToolCalls = !!anthropicStreamedToolCalls?.length;
   const isToolResult = message.type === "tool";
 
-  if (isToolResult && hideToolCalls === "1") {
+  if (isToolResult && hideToolCalls) {
     return null;
   }
 
@@ -116,7 +117,7 @@ export function AssistantMessage({
             </div>
           )}
 
-          {hideToolCalls !== "1" && (
+          {!hideToolCalls && (
             <>
               {(hasToolCalls && toolCallsHaveContents && (
                 <ToolCalls toolCalls={message.tool_calls} />
@@ -130,7 +131,7 @@ export function AssistantMessage({
 
           <CustomComponent message={message} thread={thread} />
           {isAgentInboxInterruptSchema(interrupt?.value) && isLastMessage && (
-            <ThreadView interrupt={interrupt.value[0]} />
+            <ThreadView interrupt={interrupt.value} />
           )}
           <div
             className={cn(

--- a/templates/nextjs/src/components/thread/syntax-highlighter.tsx
+++ b/templates/nextjs/src/components/thread/syntax-highlighter.tsx
@@ -1,24 +1,40 @@
-import { PrismAsyncLight } from "react-syntax-highlighter";
-import { makePrismAsyncLightSyntaxHighlighter } from "@assistant-ui/react-syntax-highlighter";
-
+import { PrismAsyncLight as SyntaxHighlighterPrism } from "react-syntax-highlighter";
 import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
 import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
-
 import { coldarkDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { FC } from "react";
 
-// register languages you want to support
-PrismAsyncLight.registerLanguage("js", tsx);
-PrismAsyncLight.registerLanguage("jsx", tsx);
-PrismAsyncLight.registerLanguage("ts", tsx);
-PrismAsyncLight.registerLanguage("tsx", tsx);
-PrismAsyncLight.registerLanguage("python", python);
+// Register languages you want to support
+SyntaxHighlighterPrism.registerLanguage("js", tsx);
+SyntaxHighlighterPrism.registerLanguage("jsx", tsx);
+SyntaxHighlighterPrism.registerLanguage("ts", tsx);
+SyntaxHighlighterPrism.registerLanguage("tsx", tsx);
+SyntaxHighlighterPrism.registerLanguage("python", python);
 
-export const SyntaxHighlighter = makePrismAsyncLightSyntaxHighlighter({
-  style: coldarkDark,
-  customStyle: {
-    margin: 0,
-    width: "100%",
-    background: "transparent",
-    padding: "1.5rem 1rem",
-  },
-});
+interface SyntaxHighlighterProps {
+  children: string;
+  language: string;
+  className?: string;
+}
+
+export const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({
+  children,
+  language,
+  className,
+}) => {
+  return (
+    <SyntaxHighlighterPrism
+      language={language}
+      style={coldarkDark}
+      customStyle={{
+        margin: 0,
+        width: "100%",
+        background: "transparent",
+        padding: "1.5rem 1rem",
+      }}
+      className={className}
+    >
+      {children}
+    </SyntaxHighlighterPrism>
+  );
+};

--- a/templates/nextjs/src/lib/agent-inbox-interrupt.ts
+++ b/templates/nextjs/src/lib/agent-inbox-interrupt.ts
@@ -2,16 +2,17 @@ import { HumanInterrupt } from "@langchain/langgraph/prebuilt";
 
 export function isAgentInboxInterruptSchema(
   value: unknown,
-): value is HumanInterrupt[] {
+): value is HumanInterrupt | HumanInterrupt[] {
+  const valueAsObject = Array.isArray(value) ? value[0] : value;
   return (
-    Array.isArray(value) &&
-    "action_request" in value[0] &&
-    typeof value[0].action_request === "object" &&
-    "config" in value[0] &&
-    typeof value[0].config === "object" &&
-    "allow_respond" in value[0].config &&
-    "allow_accept" in value[0].config &&
-    "allow_edit" in value[0].config &&
-    "allow_ignore" in value[0].config
+    valueAsObject &&
+    "action_request" in valueAsObject &&
+    typeof valueAsObject.action_request === "object" &&
+    "config" in valueAsObject &&
+    typeof valueAsObject.config === "object" &&
+    "allow_respond" in valueAsObject.config &&
+    "allow_accept" in valueAsObject.config &&
+    "allow_edit" in valueAsObject.config &&
+    "allow_ignore" in valueAsObject.config
   );
 }

--- a/templates/nextjs/src/providers/Stream.tsx
+++ b/templates/nextjs/src/providers/Stream.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React, {
   createContext,
   useContext,

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -1,8 +1,5 @@
 {
   "name": "web",
-  "readme": "https://github.com/langchain-ai/chat-langgraph/blob/main/README.md",
-  "homepage": "https://chat-langgraph.vercel.app",
-  "repository": "https://github.com/langchain-ai/chat-langgraph",
   "private": true,
   "version": "0.0.0",
   "type": "module",
@@ -16,9 +13,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@assistant-ui/react": "^0.8.0",
-    "@assistant-ui/react-markdown": "^0.8.0",
-    "@assistant-ui/react-syntax-highlighter": "^0.8.0",
     "@langchain/core": "^0.3.42",
     "@langchain/langgraph": "^0.2.55",
     "@langchain/langgraph-api": "^0.0.16",
@@ -54,9 +48,9 @@
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "sonner": "^2.0.1",
+    "nuqs": "^2.4.1",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",
-    "use-query-params": "^2.2.1",
     "use-stick-to-bottom": "^1.0.46",
     "uuid": "^11.0.5",
     "zod": "^3.24.2"

--- a/templates/vite/src/components/thread/agent-inbox/components/thread-actions-view.tsx
+++ b/templates/vite/src/components/thread/agent-inbox/components/thread-actions-view.tsx
@@ -4,7 +4,7 @@ import { InboxItemInput } from "./inbox-item-input";
 import useInterruptedActions from "../hooks/use-interrupted-actions";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
-import { StringParam, useQueryParam } from "use-query-params";
+import { useQueryState } from "nuqs";
 import { constructOpenInStudioURL } from "../utils";
 import { HumanInterrupt } from "@langchain/langgraph/prebuilt";
 
@@ -60,7 +60,7 @@ export function ThreadActionsView({
   showDescription,
   showState,
 }: ThreadActionsViewProps) {
-  const [threadId] = useQueryParam("threadId", StringParam);
+  const [threadId] = useQueryState("threadId");
   const {
     acceptAllowed,
     hasEdited,
@@ -81,7 +81,7 @@ export function ThreadActionsView({
   } = useInterruptedActions({
     interrupt,
   });
-  const [apiUrl] = useQueryParam("apiUrl", StringParam);
+  const [apiUrl] = useQueryState("apiUrl");
 
   const handleOpenInStudio = () => {
     if (!apiUrl) {
@@ -100,6 +100,7 @@ export function ThreadActionsView({
 
   const threadTitle = interrupt.action_request.action || "Unknown";
   const actionsDisabled = loading || streaming;
+  const ignoreAllowed = interrupt.config.allow_ignore;
 
   return (
     <div className="flex flex-col min-h-full w-full gap-9">
@@ -138,14 +139,16 @@ export function ThreadActionsView({
         >
           Mark as Resolved
         </Button>
-        <Button
-          variant="outline"
-          className="text-gray-800 border-gray-500 font-normal bg-white"
-          onClick={handleIgnore}
-          disabled={actionsDisabled}
-        >
-          Ignore
-        </Button>
+        {ignoreAllowed && (
+          <Button
+            variant="outline"
+            className="text-gray-800 border-gray-500 font-normal bg-white"
+            onClick={handleIgnore}
+            disabled={actionsDisabled}
+          >
+            Ignore
+          </Button>
+        )}
       </div>
 
       {/* Actions */}

--- a/templates/vite/src/components/thread/agent-inbox/hooks/use-interrupted-actions.tsx
+++ b/templates/vite/src/components/thread/agent-inbox/hooks/use-interrupted-actions.tsx
@@ -87,14 +87,6 @@ export default function useInterruptedActions({
         {
           command: {
             resume: response,
-            update: {
-              messages: [
-                {
-                  type: "human",
-                  content: `Sending type '${response[0].type}' to interrupt...`,
-                },
-              ],
-            },
           },
         },
       );
@@ -266,14 +258,6 @@ export default function useInterruptedActions({
         {
           command: {
             goto: END,
-            update: {
-              messages: [
-                {
-                  type: "human",
-                  content: "Marking thread as resolved.",
-                },
-              ],
-            },
           },
         },
       );

--- a/templates/vite/src/components/thread/agent-inbox/index.tsx
+++ b/templates/vite/src/components/thread/agent-inbox/index.tsx
@@ -5,10 +5,11 @@ import { HumanInterrupt } from "@langchain/langgraph/prebuilt";
 import { useStreamContext } from "@/providers/Stream";
 
 interface ThreadViewProps {
-  interrupt: HumanInterrupt;
+  interrupt: HumanInterrupt | HumanInterrupt[];
 }
 
 export function ThreadView({ interrupt }: ThreadViewProps) {
+  const interruptObj = Array.isArray(interrupt) ? interrupt[0] : interrupt;
   const thread = useStreamContext();
   const [showDescription, setShowDescription] = useState(false);
   const [showState, setShowState] = useState(false);
@@ -39,13 +40,13 @@ export function ThreadView({ interrupt }: ThreadViewProps) {
       {showSidePanel ? (
         <StateView
           handleShowSidePanel={handleShowSidePanel}
-          description={interrupt.description}
+          description={interruptObj.description}
           values={thread.values}
           view={showState ? "state" : "description"}
         />
       ) : (
         <ThreadActionsView
-          interrupt={interrupt}
+          interrupt={interruptObj}
           handleShowSidePanel={handleShowSidePanel}
           showState={showState}
           showDescription={showDescription}

--- a/templates/vite/src/components/thread/agent-inbox/utils.ts
+++ b/templates/vite/src/components/thread/agent-inbox/utils.ts
@@ -1,7 +1,7 @@
 import { BaseMessage, isBaseMessage } from "@langchain/core/messages";
 import { format } from "date-fns";
 import { startCase } from "lodash";
-import { HumanResponseWithEdits, SubmitType } from "./types.js";
+import { HumanResponseWithEdits, SubmitType } from "./types";
 import { HumanInterrupt } from "@langchain/langgraph/prebuilt";
 
 export function prettifyText(action: string) {

--- a/templates/vite/src/components/thread/history/index.tsx
+++ b/templates/vite/src/components/thread/history/index.tsx
@@ -4,7 +4,7 @@ import { Thread } from "@langchain/langgraph-sdk";
 import { useEffect } from "react";
 
 import { getContentString } from "../utils";
-import { useQueryParam, StringParam, BooleanParam } from "use-query-params";
+import { useQueryState, parseAsBoolean } from "nuqs";
 import {
   Sheet,
   SheetContent,
@@ -22,7 +22,7 @@ function ThreadList({
   threads: Thread[];
   onThreadClick?: (threadId: string) => void;
 }) {
-  const [threadId, setThreadId] = useQueryParam("threadId", StringParam);
+  const [threadId, setThreadId] = useQueryState("threadId");
 
   return (
     <div className="h-full flex flex-col w-full gap-2 items-start justify-start overflow-y-scroll [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-track]:bg-transparent">
@@ -71,9 +71,9 @@ function ThreadHistoryLoading() {
 
 export default function ThreadHistory() {
   const isLargeScreen = useMediaQuery("(min-width: 1024px)");
-  const [chatHistoryOpen, setChatHistoryOpen] = useQueryParam(
+  const [chatHistoryOpen, setChatHistoryOpen] = useQueryState(
     "chatHistoryOpen",
-    BooleanParam,
+    parseAsBoolean.withDefault(false),
   );
 
   const { getThreads, threads, setThreads, threadsLoading, setThreadsLoading } =

--- a/templates/vite/src/components/thread/index.tsx
+++ b/templates/vite/src/components/thread/index.tsx
@@ -21,7 +21,7 @@ import {
   PanelRightClose,
   SquarePen,
 } from "lucide-react";
-import { BooleanParam, StringParam, useQueryParam } from "use-query-params";
+import { useQueryState, parseAsBoolean } from "nuqs";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import ThreadHistory from "./history";
 import { toast } from "sonner";
@@ -68,14 +68,14 @@ function ScrollToBottom(props: { className?: string }) {
 }
 
 export function Thread() {
-  const [threadId, setThreadId] = useQueryParam("threadId", StringParam);
-  const [chatHistoryOpen, setChatHistoryOpen] = useQueryParam(
+  const [threadId, setThreadId] = useQueryState("threadId");
+  const [chatHistoryOpen, setChatHistoryOpen] = useQueryState(
     "chatHistoryOpen",
-    BooleanParam,
+    parseAsBoolean.withDefault(false),
   );
-  const [hideToolCalls, setHideToolCalls] = useQueryParam(
+  const [hideToolCalls, setHideToolCalls] = useQueryState(
     "hideToolCalls",
-    BooleanParam,
+    parseAsBoolean.withDefault(false),
   );
   const [input, setInput] = useState("");
   const [firstTokenReceived, setFirstTokenReceived] = useState(false);

--- a/templates/vite/src/components/thread/markdown-styles.css
+++ b/templates/vite/src/components/thread/markdown-styles.css
@@ -1,0 +1,45 @@
+/* Base markdown styles */
+.markdown-content code:not(pre code) {
+  background-color: rgba(0, 0, 0, 0.05);
+  padding: 0.2em 0.4em;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+.markdown-content a {
+  color: #0070f3;
+  text-decoration: none;
+}
+
+.markdown-content a:hover {
+  text-decoration: underline;
+}
+
+.markdown-content blockquote {
+  border-left: 4px solid #ddd;
+  padding-left: 1rem;
+  color: #666;
+}
+
+.markdown-content pre {
+  overflow-x: auto;
+}
+
+.markdown-content table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.markdown-content th,
+.markdown-content td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+
+.markdown-content th {
+  background-color: #f2f2f2;
+}
+
+.markdown-content tr:nth-child(even) {
+  background-color: #f9f9f9;
+}

--- a/templates/vite/src/components/thread/markdown-text.tsx
+++ b/templates/vite/src/components/thread/markdown-text.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import "@assistant-ui/react-markdown/styles/dot.css";
+import "./markdown-styles.css";
 
-import {
-  CodeHeaderProps,
-  unstable_memoizeMarkdownComponents as memoizeMarkdownComponents,
-  useIsMarkdownCodeBlock,
-} from "@assistant-ui/react-markdown";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeKatex from "rehype-katex";
@@ -20,37 +15,10 @@ import { cn } from "@/lib/utils";
 
 import "katex/dist/katex.min.css";
 
-const MarkdownTextImpl = ({ children }: { children: string }) => {
-  return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkMath]}
-      rehypePlugins={[rehypeKatex]}
-      components={defaultComponents}
-    >
-      {children}
-    </ReactMarkdown>
-  );
-};
-
-export const MarkdownText = memo(MarkdownTextImpl);
-
-const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
-  const { isCopied, copyToClipboard } = useCopyToClipboard();
-  const onCopy = () => {
-    if (!code || isCopied) return;
-    copyToClipboard(code);
-  };
-
-  return (
-    <div className="flex items-center justify-between gap-4 rounded-t-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white">
-      <span className="lowercase [&>span]:text-xs">{language}</span>
-      <TooltipIconButton tooltip="Copy" onClick={onCopy}>
-        {!isCopied && <CopyIcon />}
-        {isCopied && <CheckIcon />}
-      </TooltipIconButton>
-    </div>
-  );
-};
+interface CodeHeaderProps {
+  language?: string;
+  code: string;
+}
 
 const useCopyToClipboard = ({
   copiedDuration = 3000,
@@ -71,8 +39,26 @@ const useCopyToClipboard = ({
   return { isCopied, copyToClipboard };
 };
 
-const defaultComponents = memoizeMarkdownComponents({
-  h1: ({ className, ...props }) => (
+const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
+  const { isCopied, copyToClipboard } = useCopyToClipboard();
+  const onCopy = () => {
+    if (!code || isCopied) return;
+    copyToClipboard(code);
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-t-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white">
+      <span className="lowercase [&>span]:text-xs">{language}</span>
+      <TooltipIconButton tooltip="Copy" onClick={onCopy}>
+        {!isCopied && <CopyIcon />}
+        {isCopied && <CheckIcon />}
+      </TooltipIconButton>
+    </div>
+  );
+};
+
+const defaultComponents: any = {
+  h1: ({ className, ...props }: { className?: string }) => (
     <h1
       className={cn(
         "mb-8 scroll-m-20 text-4xl font-extrabold tracking-tight last:mb-0",
@@ -81,7 +67,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h2: ({ className, ...props }) => (
+  h2: ({ className, ...props }: { className?: string }) => (
     <h2
       className={cn(
         "mb-4 mt-8 scroll-m-20 text-3xl font-semibold tracking-tight first:mt-0 last:mb-0",
@@ -90,7 +76,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h3: ({ className, ...props }) => (
+  h3: ({ className, ...props }: { className?: string }) => (
     <h3
       className={cn(
         "mb-4 mt-6 scroll-m-20 text-2xl font-semibold tracking-tight first:mt-0 last:mb-0",
@@ -99,7 +85,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h4: ({ className, ...props }) => (
+  h4: ({ className, ...props }: { className?: string }) => (
     <h4
       className={cn(
         "mb-4 mt-6 scroll-m-20 text-xl font-semibold tracking-tight first:mt-0 last:mb-0",
@@ -108,7 +94,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h5: ({ className, ...props }) => (
+  h5: ({ className, ...props }: { className?: string }) => (
     <h5
       className={cn(
         "my-4 text-lg font-semibold first:mt-0 last:mb-0",
@@ -117,19 +103,19 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h6: ({ className, ...props }) => (
+  h6: ({ className, ...props }: { className?: string }) => (
     <h6
       className={cn("my-4 font-semibold first:mt-0 last:mb-0", className)}
       {...props}
     />
   ),
-  p: ({ className, ...props }) => (
+  p: ({ className, ...props }: { className?: string }) => (
     <p
       className={cn("mb-5 mt-5 leading-7 first:mt-0 last:mb-0", className)}
       {...props}
     />
   ),
-  a: ({ className, ...props }) => (
+  a: ({ className, ...props }: { className?: string }) => (
     <a
       className={cn(
         "text-primary font-medium underline underline-offset-4",
@@ -138,28 +124,28 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  blockquote: ({ className, ...props }) => (
+  blockquote: ({ className, ...props }: { className?: string }) => (
     <blockquote
       className={cn("border-l-2 pl-6 italic", className)}
       {...props}
     />
   ),
-  ul: ({ className, ...props }) => (
+  ul: ({ className, ...props }: { className?: string }) => (
     <ul
       className={cn("my-5 ml-6 list-disc [&>li]:mt-2", className)}
       {...props}
     />
   ),
-  ol: ({ className, ...props }) => (
+  ol: ({ className, ...props }: { className?: string }) => (
     <ol
       className={cn("my-5 ml-6 list-decimal [&>li]:mt-2", className)}
       {...props}
     />
   ),
-  hr: ({ className, ...props }) => (
+  hr: ({ className, ...props }: { className?: string }) => (
     <hr className={cn("my-5 border-b", className)} {...props} />
   ),
-  table: ({ className, ...props }) => (
+  table: ({ className, ...props }: { className?: string }) => (
     <table
       className={cn(
         "my-5 w-full border-separate border-spacing-0 overflow-y-auto",
@@ -168,7 +154,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  th: ({ className, ...props }) => (
+  th: ({ className, ...props }: { className?: string }) => (
     <th
       className={cn(
         "bg-muted px-4 py-2 text-left font-bold first:rounded-tl-lg last:rounded-tr-lg [&[align=center]]:text-center [&[align=right]]:text-right",
@@ -177,7 +163,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  td: ({ className, ...props }) => (
+  td: ({ className, ...props }: { className?: string }) => (
     <td
       className={cn(
         "border-b border-l px-4 py-2 text-left last:border-r [&[align=center]]:text-center [&[align=right]]:text-right",
@@ -186,7 +172,7 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  tr: ({ className, ...props }) => (
+  tr: ({ className, ...props }: { className?: string }) => (
     <tr
       className={cn(
         "m-0 border-b p-0 first:border-t [&:last-child>td:first-child]:rounded-bl-lg [&:last-child>td:last-child]:rounded-br-lg",
@@ -195,30 +181,65 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  sup: ({ className, ...props }) => (
+  sup: ({ className, ...props }: { className?: string }) => (
     <sup
       className={cn("[&>a]:text-xs [&>a]:no-underline", className)}
       {...props}
     />
   ),
-  pre: ({ className, ...props }) => (
+  pre: ({ className, ...props }: { className?: string }) => (
     <pre
       className={cn(
-        "overflow-x-auto rounded-b-lg bg-black p-4 text-white max-w-4xl",
+        "overflow-x-auto rounded-lg bg-black text-white max-w-4xl",
         className,
       )}
       {...props}
     />
   ),
-  code: function Code({ className, ...props }) {
-    const isCodeBlock = useIsMarkdownCodeBlock();
+  code: ({
+    className,
+    children,
+    ...props
+  }: {
+    className?: string;
+    children: React.ReactNode;
+  }) => {
+    const match = /language-(\w+)/.exec(className || "");
+
+    if (match) {
+      const language = match[1];
+      const code = String(children).replace(/\n$/, "");
+
+      return (
+        <>
+          <CodeHeader language={language} code={code} />
+          <SyntaxHighlighter language={language} className={className}>
+            {code}
+          </SyntaxHighlighter>
+        </>
+      );
+    }
+
     return (
-      <code
-        className={cn(!isCodeBlock && "rounded font-semibold", className)}
-        {...props}
-      />
+      <code className={cn("rounded font-semibold", className)} {...props}>
+        {children}
+      </code>
     );
   },
-  CodeHeader,
-  SyntaxHighlighter,
-});
+};
+
+const MarkdownTextImpl: FC<{ children: string }> = ({ children }) => {
+  return (
+    <div className="markdown-content">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+        components={defaultComponents}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+};
+
+export const MarkdownText = memo(MarkdownTextImpl);

--- a/templates/vite/src/components/thread/messages/ai.tsx
+++ b/templates/vite/src/components/thread/messages/ai.tsx
@@ -11,7 +11,7 @@ import { MessageContentComplex } from "@langchain/core/messages";
 import { Fragment } from "react/jsx-runtime";
 import { isAgentInboxInterruptSchema } from "@/lib/agent-inbox-interrupt";
 import { ThreadView } from "../agent-inbox";
-import { BooleanParam, useQueryParam } from "use-query-params";
+import { useQueryState, parseAsBoolean } from "nuqs";
 
 function CustomComponent({
   message,
@@ -74,7 +74,10 @@ export function AssistantMessage({
   handleRegenerate: (parentCheckpoint: Checkpoint | null | undefined) => void;
 }) {
   const contentString = getContentString(message.content);
-  const [hideToolCalls] = useQueryParam("hideToolCalls", BooleanParam);
+  const [hideToolCalls] = useQueryState(
+    "hideToolCalls",
+    parseAsBoolean.withDefault(false),
+  );
 
   const thread = useStreamContext();
   const isLastMessage =
@@ -128,7 +131,7 @@ export function AssistantMessage({
 
           <CustomComponent message={message} thread={thread} />
           {isAgentInboxInterruptSchema(interrupt?.value) && isLastMessage && (
-            <ThreadView interrupt={interrupt.value[0]} />
+            <ThreadView interrupt={interrupt.value} />
           )}
           <div
             className={cn(

--- a/templates/vite/src/components/thread/syntax-highlighter.tsx
+++ b/templates/vite/src/components/thread/syntax-highlighter.tsx
@@ -1,24 +1,40 @@
-import { PrismAsyncLight } from "react-syntax-highlighter";
-import { makePrismAsyncLightSyntaxHighlighter } from "@assistant-ui/react-syntax-highlighter";
-
+import { PrismAsyncLight as SyntaxHighlighterPrism } from "react-syntax-highlighter";
 import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
 import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
-
 import { coldarkDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { FC } from "react";
 
-// register languages you want to support
-PrismAsyncLight.registerLanguage("js", tsx);
-PrismAsyncLight.registerLanguage("jsx", tsx);
-PrismAsyncLight.registerLanguage("ts", tsx);
-PrismAsyncLight.registerLanguage("tsx", tsx);
-PrismAsyncLight.registerLanguage("python", python);
+// Register languages you want to support
+SyntaxHighlighterPrism.registerLanguage("js", tsx);
+SyntaxHighlighterPrism.registerLanguage("jsx", tsx);
+SyntaxHighlighterPrism.registerLanguage("ts", tsx);
+SyntaxHighlighterPrism.registerLanguage("tsx", tsx);
+SyntaxHighlighterPrism.registerLanguage("python", python);
 
-export const SyntaxHighlighter = makePrismAsyncLightSyntaxHighlighter({
-  style: coldarkDark,
-  customStyle: {
-    margin: 0,
-    width: "100%",
-    background: "transparent",
-    padding: "1.5rem 1rem",
-  },
-});
+interface SyntaxHighlighterProps {
+  children: string;
+  language: string;
+  className?: string;
+}
+
+export const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({
+  children,
+  language,
+  className,
+}) => {
+  return (
+    <SyntaxHighlighterPrism
+      language={language}
+      style={coldarkDark}
+      customStyle={{
+        margin: 0,
+        width: "100%",
+        background: "transparent",
+        padding: "1.5rem 1rem",
+      }}
+      className={className}
+    >
+      {children}
+    </SyntaxHighlighterPrism>
+  );
+};

--- a/templates/vite/src/lib/agent-inbox-interrupt.ts
+++ b/templates/vite/src/lib/agent-inbox-interrupt.ts
@@ -2,16 +2,17 @@ import { HumanInterrupt } from "@langchain/langgraph/prebuilt";
 
 export function isAgentInboxInterruptSchema(
   value: unknown,
-): value is HumanInterrupt[] {
+): value is HumanInterrupt | HumanInterrupt[] {
+  const valueAsObject = Array.isArray(value) ? value[0] : value;
   return (
-    Array.isArray(value) &&
-    "action_request" in value[0] &&
-    typeof value[0].action_request === "object" &&
-    "config" in value[0] &&
-    typeof value[0].config === "object" &&
-    "allow_respond" in value[0].config &&
-    "allow_accept" in value[0].config &&
-    "allow_edit" in value[0].config &&
-    "allow_ignore" in value[0].config
+    valueAsObject &&
+    "action_request" in valueAsObject &&
+    typeof valueAsObject.action_request === "object" &&
+    "config" in valueAsObject &&
+    typeof valueAsObject.config === "object" &&
+    "allow_respond" in valueAsObject.config &&
+    "allow_accept" in valueAsObject.config &&
+    "allow_edit" in valueAsObject.config &&
+    "allow_ignore" in valueAsObject.config
   );
 }

--- a/templates/vite/src/main.tsx
+++ b/templates/vite/src/main.tsx
@@ -1,22 +1,21 @@
-import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
+import { createRoot } from "react-dom/client";
 import { StreamProvider } from "./providers/Stream.tsx";
 import { ThreadProvider } from "./providers/Thread.tsx";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
-import { BrowserRouter } from "react-router-dom";
 import { Toaster } from "@/components/ui/sonner";
+import { NuqsAdapter } from "nuqs/adapters/react-router/v6";
+import { BrowserRouter } from "react-router-dom";
 
 createRoot(document.getElementById("root")!).render(
   <BrowserRouter>
-    <QueryParamProvider adapter={ReactRouter6Adapter}>
+    <NuqsAdapter>
       <ThreadProvider>
         <StreamProvider>
           <App />
         </StreamProvider>
       </ThreadProvider>
-    </QueryParamProvider>
-    <Toaster />
+      <Toaster />
+    </NuqsAdapter>
   </BrowserRouter>,
 );

--- a/templates/vite/src/providers/Stream.tsx
+++ b/templates/vite/src/providers/Stream.tsx
@@ -12,7 +12,7 @@ import {
   type UIMessage,
   type RemoveUIMessage,
 } from "@langchain/langgraph-sdk/react-ui";
-import { useQueryParam, StringParam } from "use-query-params";
+import { useQueryState } from "nuqs";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { LangGraphLogoSVG } from "@/components/icons/langgraph";
@@ -74,7 +74,7 @@ const StreamSession = ({
   apiUrl: string;
   assistantId: string;
 }) => {
-  const [threadId, setThreadId] = useQueryParam("threadId", StringParam);
+  const [threadId, setThreadId] = useQueryState("threadId");
   const { getThreads, setThreads } = useThreads();
   const streamValue = useTypedStream({
     apiUrl,
@@ -123,7 +123,7 @@ const StreamSession = ({
 export const StreamProvider: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
-  const [apiUrl, setApiUrl] = useQueryParam("apiUrl", StringParam);
+  const [apiUrl, setApiUrl] = useQueryState("apiUrl");
   const [apiKey, _setApiKey] = useState(() => {
     return getApiKey();
   });
@@ -133,10 +133,7 @@ export const StreamProvider: React.FC<{ children: ReactNode }> = ({
     _setApiKey(key);
   };
 
-  const [assistantId, setAssistantId] = useQueryParam(
-    "assistantId",
-    StringParam,
-  );
+  const [assistantId, setAssistantId] = useQueryState("assistantId");
 
   if (!apiUrl || !assistantId) {
     return (

--- a/templates/vite/src/providers/Thread.tsx
+++ b/templates/vite/src/providers/Thread.tsx
@@ -1,7 +1,7 @@
 import { validate } from "uuid";
 import { getApiKey } from "@/lib/api-key";
 import { Thread } from "@langchain/langgraph-sdk";
-import { useQueryParam, StringParam } from "use-query-params";
+import { useQueryState } from "nuqs";
 import {
   createContext,
   useContext,
@@ -34,8 +34,8 @@ function getThreadSearchMetadata(
 }
 
 export function ThreadProvider({ children }: { children: ReactNode }) {
-  const [apiUrl] = useQueryParam("apiUrl", StringParam);
-  const [assistantId] = useQueryParam("assistantId", StringParam);
+  const [apiUrl] = useQueryState("apiUrl");
+  const [assistantId] = useQueryState("assistantId");
   const [threads, setThreads] = useState<Thread[]>([]);
   const [threadsLoading, setThreadsLoading] = useState(false);
 


### PR DESCRIPTION
- generic intrerupt rendering support
- render HITL interrupts as array or single object
- use `nuqs` in both vite and nextjs
- improve markdown renderer
- fix showing HITL ignore button when ignore is disabled
- remove sending a human message when interrupt action taken